### PR TITLE
Add sys.platform info to RuntimeInfo

### DIFF
--- a/src/runtimeinfo/runtime_info.py
+++ b/src/runtimeinfo/runtime_info.py
@@ -1,5 +1,6 @@
 import os
 import socket
+import sys
 import uuid
 from typing import Optional, Any
 import json
@@ -13,12 +14,22 @@ import getpass
 class RuntimeInfo:
     """Information about a machine and path."""
 
+    __slots__ = (
+        "hostname",
+        "mac_address",
+        "ip_address",
+        "path",
+        "username",
+        "sys_platform",
+    )
+
     def __init__(self, path: Optional[str] = None) -> None:
         self.hostname: Optional[str] = None
         self.mac_address: Optional[str] = None
         self.ip_address: Optional[str] = None
         self.path: Optional[str] = None
         self.username: Optional[str] = None
+        self.sys_platform: Optional[str] = None
 
         try:
             self.hostname = socket.gethostname()
@@ -29,6 +40,11 @@ class RuntimeInfo:
             self.username = getpass.getuser()
         except Exception:
             self.username = None
+
+        try:
+            self.sys_platform = sys.platform
+        except Exception:
+            self.sys_platform = None
 
         try:
             node = uuid.getnode()
@@ -79,6 +95,7 @@ class RuntimeInfo:
             "mac_address": self.mac_address,
             "username": self.username,
             "path": self.path,
+            "sys_platform": self.sys_platform,
         }
         return jcs.canonicalize(data).decode("utf-8")
 
@@ -90,5 +107,6 @@ class RuntimeInfo:
             "mac_address": self.mac_address,
             "username": self.username,
             "path": self.path,
+            "sys_platform": self.sys_platform,
         }
         return json.dumps(data, ensure_ascii=False, indent=2)

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -20,6 +20,7 @@ def test_root_basic(tmp_path):
     assert r.ip_address is None or isinstance(r.ip_address, str)
     assert r.mac_address is None or isinstance(r.mac_address, str)
     assert r.username is None or isinstance(r.username, str)
+    assert r.sys_platform == sys.platform
 
 
 def test_hostname_failure(monkeypatch):
@@ -39,6 +40,7 @@ def test_root_initialization():
     root = RuntimeInfo()
     assert root.hostname == socket.gethostname()
     assert root.username == getpass.getuser()
+    assert root.sys_platform == sys.platform
 
 
 def test_root_default_path():
@@ -63,6 +65,7 @@ def test_to_json(tmp_path):
     data = json.loads(js)
     assert data['path'] == str(tmp_path)
     assert data['username'] == r.username
+    assert data['sys_platform'] == sys.platform
     assert js == jcs.canonicalize(data).decode('utf-8')
 
 
@@ -72,6 +75,7 @@ def test_str(tmp_path):
     data = json.loads(s)
     assert data['path'] == str(tmp_path)
     assert data['username'] == r.username
+    assert data['sys_platform'] == sys.platform
 
 
 def test_exclude_loopback(monkeypatch):


### PR DESCRIPTION
## Summary
- gather `sys.platform` in `RuntimeInfo`
- restrict attributes via `__slots__`
- update tests

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864acb15448832b910e7768968d086f